### PR TITLE
fix: PR review should-fix items — Square errors, waiverReceived split, security headers, cron filter

### DIFF
--- a/apps/web/drizzle/migrations/0001_waiver_received_column.sql
+++ b/apps/web/drizzle/migrations/0001_waiver_received_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "bookings" ADD COLUMN "waiver_received" boolean DEFAULT false NOT NULL;

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1778026244842,
       "tag": "0000_melted_riptide",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1746569200000,
+      "tag": "0001_waiver_received_column",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,16 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: { unoptimized: true },
+  async headers() {
+    return [
+      {
+        source: '/waiver',
+        headers: [
+          { key: 'Referrer-Policy', value: 'strict-origin' },
+        ],
+      },
+    ]
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/app/api/cron/waiver-reminders/route.ts
+++ b/apps/web/src/app/api/cron/waiver-reminders/route.ts
@@ -28,6 +28,7 @@ export async function GET(req: NextRequest) {
     .where(
       and(
         eq(bookings.requiresWaiver, true),
+        eq(bookings.waiverReceived, false),
         eq(bookings.waiverSent, false),
         gte(bookings.startsAt, now),
         lte(bookings.startsAt, threeDaysFromNow)
@@ -43,7 +44,8 @@ export async function GET(req: NextRequest) {
       .where(
         and(
           eq(waiverTokens.bookingId, booking.bookingId),
-          eq(waiverTokens.used, false)
+          eq(waiverTokens.used, false),
+          gte(waiverTokens.expiresAt, now)
         )
       )
       .limit(1)

--- a/apps/web/src/app/api/waivers/sign/route.ts
+++ b/apps/web/src/app/api/waivers/sign/route.ts
@@ -40,7 +40,7 @@ export async function POST(req: NextRequest) {
 
     await db.update(waiverTokens).set({ used: true }).where(eq(waiverTokens.id, tokenRow.id))
 
-    await db.update(bookings).set({ requiresWaiver: false }).where(eq(bookings.id, tokenRow.bookingId))
+    await db.update(bookings).set({ waiverReceived: true }).where(eq(bookings.id, tokenRow.bookingId))
 
     const signedAt = new Date().toLocaleDateString('en-US', {
       year: 'numeric', month: 'long', day: 'numeric',

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -26,6 +26,7 @@ export const bookings = pgTable('bookings', {
   serviceId: text('service_id').notNull(),
   startsAt: timestamp('starts_at').notNull(),
   requiresWaiver: boolean('requires_waiver').default(false).notNull(),
+  waiverReceived: boolean('waiver_received').default(false).notNull(),
   waiverSent: boolean('waiver_sent').default(false).notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 })

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -15,10 +15,17 @@ export function isOtpExpired(expiresAt: Date): boolean {
 }
 
 export interface SessionData {
-  customerId: string
-  phone: string
-  email: string
-  squareCustomerId: string
+  customerId?: string
+  phone?: string
+  email?: string
+  squareCustomerId?: string
+}
+
+/** Narrows a session to a verified authenticated state. */
+export function isAuthenticated(
+  session: SessionData
+): session is Required<SessionData> {
+  return !!(session.customerId && session.phone && session.email && session.squareCustomerId)
 }
 
 export async function getSession() {

--- a/apps/web/src/lib/square.ts
+++ b/apps/web/src/lib/square.ts
@@ -7,7 +7,7 @@ const environment =
     : SquareEnvironment.Sandbox
 
 export const squareClient = new SquareClient({
-  token: process.env.SQUARE_ACCESS_TOKEN!,
+  token: process.env.SQUARE_ACCESS_TOKEN ?? '',
   environment,
 })
 
@@ -29,7 +29,9 @@ export async function upsertSquareCustomer(
   })
 
   if (searchResult.customers && searchResult.customers.length > 0) {
-    return { squareCustomerId: searchResult.customers[0].id! }
+    const id = searchResult.customers[0].id
+    if (!id) throw new Error('Square returned a customer with no ID')
+    return { squareCustomerId: id }
   }
 
   const parts = name.trim().split(' ')
@@ -41,7 +43,9 @@ export async function upsertSquareCustomer(
     referenceId: 'bba-web',
   })
 
-  return { squareCustomerId: createResult.customer!.id! }
+  const id = createResult.customer?.id
+  if (!id) throw new Error('Square customer creation returned no customer ID')
+  return { squareCustomerId: id }
 }
 
 /**
@@ -59,7 +63,9 @@ export async function saveCardOnFile(
       customerId: squareCustomerId,
     },
   })
-  return result.card!.id!
+  const cardId = result.card?.id
+  if (!cardId) throw new Error('Square card creation returned no card ID')
+  return cardId
 }
 
 /**
@@ -90,7 +96,9 @@ export async function createSquareAppointment(params: {
       ],
     },
   })
-  return result.booking!.id!
+  const bookingId = result.booking?.id
+  if (!bookingId) throw new Error('Square appointment creation returned no booking ID')
+  return bookingId
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`square.ts`** — Replace 4 `!` non-null assertions with explicit guarded throws; `SQUARE_ACCESS_TOKEN!` → `?? ''` (empty token fails at request time with a clear auth error, not at build time)
- **`schema.ts` + migration** — Add `waiver_received` boolean column to `bookings`; split the dual-purpose `requiresWaiver` into two independent facts: `requiresWaiver` (immutable — service requires it) and `waiverReceived` (mutable — customer has signed)
- **`sign/route.ts`** — Booking update now sets `waiverReceived: true` instead of clearing `requiresWaiver`
- **`cron/waiver-reminders/route.ts`** — Booking query adds `waiverReceived: false` filter; waiver token query adds `gte(expiresAt, now)` to avoid sending expired links
- **`next.config.ts`** — `Referrer-Policy: strict-origin` header on `/waiver` route
- **`auth.ts`** — `SessionData` fields made optional (required for iron-session); `isAuthenticated()` type guard added

## Migration

After merging, run against the live Neon database:
```bash
cd apps/web && npx drizzle-kit migrate
```

## Test Plan
- [x] 5/5 Vitest unit tests passing
- [ ] Run `npx drizzle-kit migrate` against Neon
- [ ] Manually sign a waiver and confirm `waiverReceived = true` in DB (not `requiresWaiver = false`)
- [ ] Confirm Vercel deployment sets `Referrer-Policy` header on `/waiver` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)