### PR TITLE
feat: replace waiverReceived boolean with waiverReceivedAt timestamp

### DIFF
--- a/apps/web/drizzle/migrations/0002_waiver_received_at_timestamp.sql
+++ b/apps/web/drizzle/migrations/0002_waiver_received_at_timestamp.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "bookings" DROP COLUMN "waiver_received";
+ALTER TABLE "bookings" ADD COLUMN "waiver_received_at" timestamp;

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1746569200000,
       "tag": "0001_waiver_received_column",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1746569400000,
+      "tag": "0002_waiver_received_at_timestamp",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/app/api/cron/waiver-reminders/route.ts
+++ b/apps/web/src/app/api/cron/waiver-reminders/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/db'
 import { bookings, customers, waiverTokens } from '@/db/schema'
 import { sendWaiverReminderSms } from '@/lib/sms'
-import { eq, and, lte, gte } from 'drizzle-orm'
+import { eq, and, lte, gte, isNull } from 'drizzle-orm'
 
 // Secured with a secret header — Vercel sends this automatically
 export async function GET(req: NextRequest) {
@@ -28,7 +28,7 @@ export async function GET(req: NextRequest) {
     .where(
       and(
         eq(bookings.requiresWaiver, true),
-        eq(bookings.waiverReceived, false),
+        isNull(bookings.waiverReceivedAt),
         eq(bookings.waiverSent, false),
         gte(bookings.startsAt, now),
         lte(bookings.startsAt, threeDaysFromNow)

--- a/apps/web/src/app/api/waivers/sign/route.ts
+++ b/apps/web/src/app/api/waivers/sign/route.ts
@@ -40,7 +40,7 @@ export async function POST(req: NextRequest) {
 
     await db.update(waiverTokens).set({ used: true }).where(eq(waiverTokens.id, tokenRow.id))
 
-    await db.update(bookings).set({ waiverReceived: true }).where(eq(bookings.id, tokenRow.bookingId))
+    await db.update(bookings).set({ waiverReceivedAt: new Date() }).where(eq(bookings.id, tokenRow.bookingId))
 
     const signedAt = new Date().toLocaleDateString('en-US', {
       year: 'numeric', month: 'long', day: 'numeric',

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -26,7 +26,7 @@ export const bookings = pgTable('bookings', {
   serviceId: text('service_id').notNull(),
   startsAt: timestamp('starts_at').notNull(),
   requiresWaiver: boolean('requires_waiver').default(false).notNull(),
-  waiverReceived: boolean('waiver_received').default(false).notNull(),
+  waiverReceivedAt: timestamp('waiver_received_at'),
   waiverSent: boolean('waiver_sent').default(false).notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 })


### PR DESCRIPTION
## Summary

- **`schema.ts`** — `waiverReceived: boolean` replaced with `waiverReceivedAt: timestamp | null`; null means not yet received
- **`0002_waiver_received_at_timestamp.sql`** — drops `waiver_received`, adds `waiver_received_at`
- **`sign/route.ts`** — stamps `waiverReceivedAt: new Date()` on waiver submission
- **`cron/route.ts`** — `isNull(bookings.waiverReceivedAt)` replaces the boolean equality check

A nullable timestamp is strictly better than a boolean: you get the signed date for auditing and `IS NOT NULL` is the natural "has been signed" predicate.

## Migration

Run against Neon after merging (along with 0001):
```bash
cd apps/web && npx drizzle-kit migrate
```

## Test Plan
- [x] 5/5 Vitest tests passing
- [ ] Sign a waiver → confirm `waiver_received_at` is populated with a real timestamp
- [ ] Confirm cron skips bookings where `waiver_received_at IS NOT NULL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)