### PR TITLE
feat: waiverSentAt timestamp + per-service waiver validity windows

### DIFF
--- a/apps/web/drizzle/migrations/0003_waiver_sent_at_and_expiry.sql
+++ b/apps/web/drizzle/migrations/0003_waiver_sent_at_and_expiry.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "bookings" DROP COLUMN "waiver_sent";
+ALTER TABLE "bookings" ADD COLUMN "waiver_sent_at" timestamp;
+ALTER TABLE "waivers" ADD COLUMN "expires_at" timestamp NOT NULL DEFAULT (NOW() + INTERVAL '1 year');
+ALTER TABLE "waivers" ALTER COLUMN "expires_at" DROP DEFAULT;

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1746569400000,
       "tag": "0002_waiver_received_at_timestamp",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1746569600000,
+      "tag": "0003_waiver_sent_at_and_expiry",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/app/api/bookings/route.ts
+++ b/apps/web/src/app/api/bookings/route.ts
@@ -4,7 +4,7 @@ import { db } from '@/db'
 import { bookings, waivers, waiverTokens } from '@/db/schema'
 import { getSession, CURRENT_WAIVER_VERSION } from '@/lib/auth'
 import { saveCardOnFile, createSquareAppointment } from '@/lib/square'
-import { eq, and } from 'drizzle-orm'
+import { eq, and, gt } from 'drizzle-orm'
 import { z } from 'zod'
 
 const Schema = z.object({
@@ -77,7 +77,8 @@ export async function POST(req: NextRequest) {
       .where(
         and(
           eq(waivers.customerId, session.customerId),
-          eq(waivers.waiverVersion, CURRENT_WAIVER_VERSION)
+          eq(waivers.waiverVersion, CURRENT_WAIVER_VERSION),
+          gt(waivers.expiresAt, new Date())
         )
       )
       .limit(1)
@@ -95,7 +96,6 @@ export async function POST(req: NextRequest) {
         serviceId,
         startsAt: new Date(startsAt),
         requiresWaiver: needsWaiver,
-        waiverSent: false,
       })
       .returning()
 

--- a/apps/web/src/app/api/cron/waiver-reminders/route.ts
+++ b/apps/web/src/app/api/cron/waiver-reminders/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
       and(
         eq(bookings.requiresWaiver, true),
         isNull(bookings.waiverReceivedAt),
-        eq(bookings.waiverSent, false),
+        isNull(bookings.waiverSentAt),
         gte(bookings.startsAt, now),
         lte(bookings.startsAt, threeDaysFromNow)
       )
@@ -61,7 +61,7 @@ export async function GET(req: NextRequest) {
 
     try {
       await sendWaiverReminderSms(booking.phone, booking.name, appointmentDate, waiverUrl)
-      await db.update(bookings).set({ waiverSent: true }).where(eq(bookings.id, booking.bookingId))
+      await db.update(bookings).set({ waiverSentAt: new Date() }).where(eq(bookings.id, booking.bookingId))
       sent++
     } catch (err) {
       console.error(`Failed to send waiver reminder for booking ${booking.bookingId}:`, err)

--- a/apps/web/src/app/api/waivers/sign/route.ts
+++ b/apps/web/src/app/api/waivers/sign/route.ts
@@ -4,6 +4,7 @@ import { db } from '@/db'
 import { waivers, waiverTokens, bookings, customers } from '@/db/schema'
 import { CURRENT_WAIVER_VERSION } from '@/lib/auth'
 import { appendCustomerNote } from '@/lib/square'
+import { services } from '@/lib/services-data'
 import { eq, and } from 'drizzle-orm'
 import { z } from 'zod'
 
@@ -20,8 +21,16 @@ export async function POST(req: NextRequest) {
   }
 
   const [tokenRow] = await db
-    .select()
+    .select({
+      id: waiverTokens.id,
+      customerId: waiverTokens.customerId,
+      bookingId: waiverTokens.bookingId,
+      expiresAt: waiverTokens.expiresAt,
+      used: waiverTokens.used,
+      serviceId: bookings.serviceId,
+    })
     .from(waiverTokens)
+    .innerJoin(bookings, eq(bookings.id, waiverTokens.bookingId))
     .where(and(eq(waiverTokens.token, parsed.data.token), eq(waiverTokens.used, false)))
     .limit(1)
 
@@ -31,10 +40,15 @@ export async function POST(req: NextRequest) {
 
   const ip = req.headers.get('x-forwarded-for') ?? req.headers.get('x-real-ip') ?? null
 
+  const service = services.find((s) => s.id === tokenRow.serviceId)
+  const validityDays = service?.waiverValidityDays ?? 365
+  const waiverExpiresAt = new Date(Date.now() + validityDays * 24 * 60 * 60 * 1000)
+
   try {
     await db.insert(waivers).values({
       customerId: tokenRow.customerId,
       waiverVersion: CURRENT_WAIVER_VERSION,
+      expiresAt: waiverExpiresAt,
       ipAddress: ip,
     })
 

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -27,7 +27,7 @@ export const bookings = pgTable('bookings', {
   startsAt: timestamp('starts_at').notNull(),
   requiresWaiver: boolean('requires_waiver').default(false).notNull(),
   waiverReceivedAt: timestamp('waiver_received_at'),
-  waiverSent: boolean('waiver_sent').default(false).notNull(),
+  waiverSentAt: timestamp('waiver_sent_at'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 })
 
@@ -46,6 +46,7 @@ export const waivers = pgTable('waivers', {
   customerId: uuid('customer_id').references(() => customers.id).notNull(),
   waiverVersion: text('waiver_version').notNull(),
   signedAt: timestamp('signed_at').defaultNow().notNull(),
+  expiresAt: timestamp('expires_at').notNull(),
   ipAddress: text('ip_address'),
 })
 

--- a/apps/web/src/lib/services-data.ts
+++ b/apps/web/src/lib/services-data.ts
@@ -11,6 +11,8 @@ export interface Service {
   requiresDeposit?: boolean
   /** True for PMU and first-time lash services that require a signed consent waiver */
   requiresWaiver?: boolean
+  /** Days a signed waiver remains valid for this service. Only set when requiresWaiver is true. */
+  waiverValidityDays?: number
 }
 
 export const categories = [
@@ -120,6 +122,21 @@ const WAIVER_REQUIRED = new Set([
   'service30', // Classic 22-28 days
 ])
 
+/**
+ * How long a signed waiver is valid for each service (in days).
+ * Lash services renew annually; PMU waivers cover the full touch-up cycle.
+ */
+const WAIVER_VALIDITY_DAYS: Record<string, number> = {
+  // Lash services — 1 year
+  'service1': 365, 'service2': 365, 'service3': 365, 'service4': 365, 'service5': 365,
+  'service15': 365, 'service16': 365, 'service17': 365, 'service18': 365,
+  'service20': 365, 'service27': 365, 'service28': 365, 'service29': 365, 'service30': 365,
+  // PMU services — 2 years
+  'service8': 730, 'service9': 730, 'service10': 730, 'service12': 730, 'service13': 730,
+  'service14': 730, 'service19': 730, 'service21': 730, 'service22': 730,
+  'service23': 730, 'service31': 730,
+}
+
 export const services: Service[] = RAW_SERVICES.map((s) => ({
   id: s.id,
   name: s.name,
@@ -128,6 +145,7 @@ export const services: Service[] = RAW_SERVICES.map((s) => ({
   price: typeof s.price === 'string' ? 0 : s.price,
   requiresDeposit: DEPOSIT_REQUIRED.has(s.id),
   requiresWaiver: WAIVER_REQUIRED.has(s.id),
+  waiverValidityDays: WAIVER_VALIDITY_DAYS[s.id],
 }))
 
 export function getServicesByCategory(category: string): Service[] {


### PR DESCRIPTION
## Summary

- **`waiverSentAt` timestamp** — `waiverSent: boolean` replaced with `waiverSentAt: timestamp | null`; records exactly when the reminder SMS was dispatched
- **Per-service waiver validity** — `waiverValidityDays` added to the `Service` interface and populated in services-data:
  - Lash services → 365 days
  - PMU services → 730 days
- **`waivers.expiresAt`** — stamped at sign time using the service's validity window; defaults to 365 days if service not found
- **Booking route** — waiver existence check now includes `expiresAt > now` so customers with valid waivers skip the sign step entirely
- **Sign route** — joins `bookings` to fetch `serviceId`, looks up `waiverValidityDays` from services data, and sets `expiresAt` on the new waiver row
- **Cron route** — uses `isNull(waiverSentAt)` / `set({ waiverSentAt: new Date() })`
- **Migration `0003`** — drops `waiver_sent`, adds `waiver_sent_at` and `waivers.expires_at`

## Migration

Run after merging (applies 0001 → 0002 → 0003 in order):
```bash
cd apps/web && npx drizzle-kit migrate
```

## Test Plan
- [x] 5/5 Vitest tests passing
- [ ] Book a lash service → sign waiver → confirm `expires_at` is ~1 year from now
- [ ] Book a PMU service → sign waiver → confirm `expires_at` is ~2 years from now
- [ ] Book same service again before expiry → confirm `needsWaiver: false` in booking response

🤖 Generated with [Claude Code](https://claude.com/claude-code)