### PR TITLE
fix: guard service_overrides DB queries against missing table

### DIFF
--- a/src/app/admin/services/page.tsx
+++ b/src/app/admin/services/page.tsx
@@ -9,7 +9,7 @@ import type { PublicCategory } from '@/lib/services-data'
 export default async function ServicesPage() {
   const [services, overrides] = await Promise.all([
     fetchSquareServices().catch(() => []),
-    db.select().from(serviceOverrides),
+    db.select().from(serviceOverrides).catch(() => []),
   ])
 
   // Build the override map the client component needs: variationId → category

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -43,7 +43,7 @@ async function getCategories(img: Record<string, string>) {
   // Fetch Square services and any category overrides Amy has set in the admin
   const [squareServices, overrides] = await Promise.all([
     fetchSquareServices().catch(() => []),
-    db.select().from(serviceOverrides),
+    db.select().from(serviceOverrides).catch(() => []),
   ])
 
   // Build a lookup: squareVariationId → overridden category


### PR DESCRIPTION
Adds .catch(() => []) to both service_overrides queries so a missing table in production doesn't crash the page. 🤖 Generated with Claude Code